### PR TITLE
mirror-intel: limit mem usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,6 +256,8 @@ services:
         hard: 120000
     volumes:
       - "/mnt/disk2/mirror-intel-cache:/mnt/cache"
+    mem_limit: 15G
+    memswap_limit: 15G
     
 networks:
   service-net:

--- a/mirror-intel/Rocket.toml
+++ b/mirror-intel/Rocket.toml
@@ -1,10 +1,10 @@
 [default]
 address = "0.0.0.0"
 concurrent_download = 256
-max_pending_task = 2048
+max_pending_task = 65536
 user_agent = "mirror-intel / 0.1 (siyuan.internal.sjtug.org)"
-file_threshold_mb = 30
-ignore_threshold_mb = 1024
+file_threshold_mb = 10
+ignore_threshold_mb = 4096
 
 [default.endpoints]
 rustup = "https://static.rust-lang.org"


### PR DESCRIPTION
Now we have fully-synchronized pypi, and we can add back memory limits.