### PR TITLE
caddy: fix git redirect, support graceful reload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ caddy-hash-password:
 caddy-gen-local:
 	cd caddy-gen && pipenv run python caddy-gen.py -i ../lug/config.local.yaml -o ../caddy/Caddyfile -D
 
+caddy-reload:
+	docker-compose exec -w /etc/caddy caddy caddy reload
+
 lug-format-config: # You need to install prettier from npm to use this functionality
 	prettier lug/*.yaml -w
 

--- a/caddy-gen/config.py
+++ b/caddy-gen/config.py
@@ -7,4 +7,4 @@ MIRROR_INTEL_ADDR = 'siyuan-mirror-intel:8000'
 LUG_EXPORTER_ADDR = 'siyuan-lug:8081'
 MIRROR_INTEL_LIST = ['crates.io', 'pypi-packages', 'flathub', 'fedora-ostree',
                      'fedora-iot', 'rust-static', 'homebrew-bottles', 'dart-pub', 'guix',
-                     'pytorch-wheels', 'sjtug-internal', 'flutter_infra']
+                     'pytorch-wheels', 'sjtug-internal', 'flutter_infra', 'linuxbrew-bottles']

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -282,6 +282,7 @@ ftp.sjtu.edu.cn {
         not path /pytorch-wheels/*
         not path /sjtug-internal/*
         not path /flutter_infra/*
+        not path /linuxbrew-bottles/*
     }
     encode @not_mirror_intel_repo gzip zstd
 
@@ -359,6 +360,9 @@ ftp.sjtu.edu.cn {
     route /flutter_infra/* {
         reverse_proxy siyuan-mirror-intel:8000
     }
+    route /linuxbrew-bottles/* {
+        reverse_proxy siyuan-mirror-intel:8000
+    }
 
     @hidden {
         path */.*
@@ -368,6 +372,8 @@ ftp.sjtu.edu.cn {
         path /lug/v1/admin/*
     }
     respond @reject_lug_api 403
+
+    header * x-sjtug-mirror-id siyuan
 
     redir /centos /centos/ 301
     file_server /centos/* browse {
@@ -486,38 +492,43 @@ ftp.sjtu.edu.cn {
     }
     redir /git/linuxbrew-core.git /git/linuxbrew-core.git/ 301
     route /git/linuxbrew-core.git/* {
-        uri strip_prefix /git/linuxbrew-core.git/
-        redir * https://git.sjtu.edu.cn/sjtug/linuxbrew-core.git/{uri} 302
+        uri strip_prefix /git/linuxbrew-core.git
+        redir * https://git.sjtu.edu.cn/sjtug/linuxbrew-core.git{uri} 302
     }
     redir /git/homebrew-services.git /git/homebrew-services.git/ 301
     route /git/homebrew-services.git/* {
-        uri strip_prefix /git/homebrew-services.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-services.git/{uri} 302
+        uri strip_prefix /git/homebrew-services.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-services.git{uri} 302
     }
     redir /git/homebrew-cask-drivers.git /git/homebrew-cask-drivers.git/ 301
     route /git/homebrew-cask-drivers.git/* {
-        uri strip_prefix /git/homebrew-cask-drivers.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-drivers.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-drivers.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-drivers.git{uri} 302
     }
     redir /git/homebrew-cask-fonts.git /git/homebrew-cask-fonts.git/ 301
     route /git/homebrew-cask-fonts.git/* {
-        uri strip_prefix /git/homebrew-cask-fonts.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-fonts.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-fonts.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-fonts.git{uri} 302
     }
     redir /git/homebrew-cask-versions.git /git/homebrew-cask-versions.git/ 301
     route /git/homebrew-cask-versions.git/* {
-        uri strip_prefix /git/homebrew-cask-versions.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-versions.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-versions.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-versions.git{uri} 302
     }
     redir /git/guix.git /git/guix.git/ 301
     route /git/guix.git/* {
-        uri strip_prefix /git/guix.git/
-        redir * https://git.sjtu.edu.cn/sjtug/guix.git/{uri} 302
+        uri strip_prefix /git/guix.git
+        redir * https://git.sjtu.edu.cn/sjtug/guix.git{uri} 302
+    }
+    redir /git/llvm-project.git /git/llvm-project.git/ 301
+    route /git/llvm-project.git/* {
+        uri strip_prefix /git/llvm-project.git
+        redir * https://git.sjtu.edu.cn/sjtug/llvm-project.git{uri} 302
     }
     redir /git/flutter-sdk.git /git/flutter-sdk.git/ 301
     route /git/flutter-sdk.git/* {
-        uri strip_prefix /git/flutter-sdk.git/
-        redir * https://git.sjtu.edu.cn/sjtug/flutter-sdk.git/{uri} 302
+        uri strip_prefix /git/flutter-sdk.git
+        redir * https://git.sjtu.edu.cn/sjtug/flutter-sdk.git{uri} 302
     }
 }
 
@@ -805,6 +816,7 @@ siyuan.internal.sjtug.org {
         not path /pytorch-wheels/*
         not path /sjtug-internal/*
         not path /flutter_infra/*
+        not path /linuxbrew-bottles/*
     }
     encode @not_mirror_intel_repo gzip zstd
 
@@ -882,6 +894,9 @@ siyuan.internal.sjtug.org {
     route /flutter_infra/* {
         reverse_proxy siyuan-mirror-intel:8000
     }
+    route /linuxbrew-bottles/* {
+        reverse_proxy siyuan-mirror-intel:8000
+    }
 
     @hidden {
         path */.*
@@ -891,6 +906,8 @@ siyuan.internal.sjtug.org {
         path /lug/v1/admin/*
     }
     respond @reject_lug_api 403
+
+    header * x-sjtug-mirror-id siyuan
 
     redir /centos /centos/ 301
     file_server /centos/* browse {
@@ -1009,38 +1026,43 @@ siyuan.internal.sjtug.org {
     }
     redir /git/linuxbrew-core.git /git/linuxbrew-core.git/ 301
     route /git/linuxbrew-core.git/* {
-        uri strip_prefix /git/linuxbrew-core.git/
-        redir * https://git.sjtu.edu.cn/sjtug/linuxbrew-core.git/{uri} 302
+        uri strip_prefix /git/linuxbrew-core.git
+        redir * https://git.sjtu.edu.cn/sjtug/linuxbrew-core.git{uri} 302
     }
     redir /git/homebrew-services.git /git/homebrew-services.git/ 301
     route /git/homebrew-services.git/* {
-        uri strip_prefix /git/homebrew-services.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-services.git/{uri} 302
+        uri strip_prefix /git/homebrew-services.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-services.git{uri} 302
     }
     redir /git/homebrew-cask-drivers.git /git/homebrew-cask-drivers.git/ 301
     route /git/homebrew-cask-drivers.git/* {
-        uri strip_prefix /git/homebrew-cask-drivers.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-drivers.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-drivers.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-drivers.git{uri} 302
     }
     redir /git/homebrew-cask-fonts.git /git/homebrew-cask-fonts.git/ 301
     route /git/homebrew-cask-fonts.git/* {
-        uri strip_prefix /git/homebrew-cask-fonts.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-fonts.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-fonts.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-fonts.git{uri} 302
     }
     redir /git/homebrew-cask-versions.git /git/homebrew-cask-versions.git/ 301
     route /git/homebrew-cask-versions.git/* {
-        uri strip_prefix /git/homebrew-cask-versions.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-versions.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-versions.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-versions.git{uri} 302
     }
     redir /git/guix.git /git/guix.git/ 301
     route /git/guix.git/* {
-        uri strip_prefix /git/guix.git/
-        redir * https://git.sjtu.edu.cn/sjtug/guix.git/{uri} 302
+        uri strip_prefix /git/guix.git
+        redir * https://git.sjtu.edu.cn/sjtug/guix.git{uri} 302
+    }
+    redir /git/llvm-project.git /git/llvm-project.git/ 301
+    route /git/llvm-project.git/* {
+        uri strip_prefix /git/llvm-project.git
+        redir * https://git.sjtu.edu.cn/sjtug/llvm-project.git{uri} 302
     }
     redir /git/flutter-sdk.git /git/flutter-sdk.git/ 301
     route /git/flutter-sdk.git/* {
-        uri strip_prefix /git/flutter-sdk.git/
-        redir * https://git.sjtu.edu.cn/sjtug/flutter-sdk.git/{uri} 302
+        uri strip_prefix /git/flutter-sdk.git
+        redir * https://git.sjtu.edu.cn/sjtug/flutter-sdk.git{uri} 302
     }
 }
 
@@ -1062,6 +1084,7 @@ siyuan.internal.sjtug.org {
         not path /pytorch-wheels/*
         not path /sjtug-internal/*
         not path /flutter_infra/*
+        not path /linuxbrew-bottles/*
     }
     encode @not_mirror_intel_repo gzip zstd
 
@@ -1139,6 +1162,9 @@ siyuan.internal.sjtug.org {
     route /flutter_infra/* {
         reverse_proxy siyuan-mirror-intel:8000
     }
+    route /linuxbrew-bottles/* {
+        reverse_proxy siyuan-mirror-intel:8000
+    }
 
     @hidden {
         path */.*
@@ -1148,6 +1174,8 @@ siyuan.internal.sjtug.org {
         path /lug/v1/admin/*
     }
     respond @reject_lug_api 403
+
+    header * x-sjtug-mirror-id siyuan
 
     redir /centos /centos/ 301
     file_server /centos/* browse {
@@ -1266,38 +1294,43 @@ siyuan.internal.sjtug.org {
     }
     redir /git/linuxbrew-core.git /git/linuxbrew-core.git/ 301
     route /git/linuxbrew-core.git/* {
-        uri strip_prefix /git/linuxbrew-core.git/
-        redir * https://git.sjtu.edu.cn/sjtug/linuxbrew-core.git/{uri} 302
+        uri strip_prefix /git/linuxbrew-core.git
+        redir * https://git.sjtu.edu.cn/sjtug/linuxbrew-core.git{uri} 302
     }
     redir /git/homebrew-services.git /git/homebrew-services.git/ 301
     route /git/homebrew-services.git/* {
-        uri strip_prefix /git/homebrew-services.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-services.git/{uri} 302
+        uri strip_prefix /git/homebrew-services.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-services.git{uri} 302
     }
     redir /git/homebrew-cask-drivers.git /git/homebrew-cask-drivers.git/ 301
     route /git/homebrew-cask-drivers.git/* {
-        uri strip_prefix /git/homebrew-cask-drivers.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-drivers.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-drivers.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-drivers.git{uri} 302
     }
     redir /git/homebrew-cask-fonts.git /git/homebrew-cask-fonts.git/ 301
     route /git/homebrew-cask-fonts.git/* {
-        uri strip_prefix /git/homebrew-cask-fonts.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-fonts.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-fonts.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-fonts.git{uri} 302
     }
     redir /git/homebrew-cask-versions.git /git/homebrew-cask-versions.git/ 301
     route /git/homebrew-cask-versions.git/* {
-        uri strip_prefix /git/homebrew-cask-versions.git/
-        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-versions.git/{uri} 302
+        uri strip_prefix /git/homebrew-cask-versions.git
+        redir * https://git.sjtu.edu.cn/sjtug/homebrew-cask-versions.git{uri} 302
     }
     redir /git/guix.git /git/guix.git/ 301
     route /git/guix.git/* {
-        uri strip_prefix /git/guix.git/
-        redir * https://git.sjtu.edu.cn/sjtug/guix.git/{uri} 302
+        uri strip_prefix /git/guix.git
+        redir * https://git.sjtu.edu.cn/sjtug/guix.git{uri} 302
+    }
+    redir /git/llvm-project.git /git/llvm-project.git/ 301
+    route /git/llvm-project.git/* {
+        uri strip_prefix /git/llvm-project.git
+        redir * https://git.sjtu.edu.cn/sjtug/llvm-project.git{uri} 302
     }
     redir /git/flutter-sdk.git /git/flutter-sdk.git/ 301
     route /git/flutter-sdk.git/* {
-        uri strip_prefix /git/flutter-sdk.git/
-        redir * https://git.sjtu.edu.cn/sjtug/flutter-sdk.git/{uri} 302
+        uri strip_prefix /git/flutter-sdk.git
+        redir * https://git.sjtu.edu.cn/sjtug/flutter-sdk.git{uri} 302
     }
 }
 
@@ -1305,11 +1338,13 @@ k8s-gcr-io.siyuan.internal.sjtug.org {
     encode  gzip zstd
 
     reverse_proxy siyuan-gcr-registry:80
+    header * x-sjtug-mirror-id siyuan
 }
 
 docker.siyuan.internal.sjtug.org {
     encode  gzip zstd
 
     reverse_proxy siyuan-docker-registry:80
+    header * x-sjtug-mirror-id siyuan
 }
 

--- a/integration-test/.gitignore
+++ b/integration-test/.gitignore
@@ -1,1 +1,2 @@
 .pytest_cache/
+__pycache__

--- a/integration-test/siyuan_test.py
+++ b/integration-test/siyuan_test.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "mirrors.internal.skyzh.xyz"
+BASE_URL = "siyuan.internal.sjtug.org"
 
 """
 Here we take Debian repo as an example. It should be served on both http
@@ -92,3 +92,18 @@ Also an edge case, we should never concat two directories
 def test_debian_concat():
     response = requests.get(f"http://{BASE_URL}/debiandoc/source-unpack.txt")
     assert response.status_code == 404
+
+"""
+For git repos, should redirect to git.sjtu
+"""
+
+def test_git_redirect():
+    response = requests.get(f"http://{BASE_URL}/git/llvm-project.git")
+    assert response.url == f"https://git.sjtu.edu.cn/sjtug/llvm-project.git"
+
+"""
+We should return x-sjtug-mirror-id in header
+"""
+def test_mirror_id():
+    response = requests.get(f"http://{BASE_URL}")
+    assert response.headers["x-sjtug-mirror-id"] == "siyuan"

--- a/lug/config.yaml
+++ b/lug/config.yaml
@@ -328,7 +328,7 @@ repos:
     interval: 3700
     name: git/llvm-project.git
     source: https://github.com/llvm/llvm-project.git
-    path: /srv/disk2/git/guix.git
+    path: /srv/disk2/git/llvm-project.git
     target: https://git.sjtu.edu.cn/sjtug/llvm-project.git
     <<: *oneshot_common
   - type: shell_script

--- a/lug/worker-script/git.sh
+++ b/lug/worker-script/git.sh
@@ -4,14 +4,12 @@ set -e
 
 if [[ ! -d $LUG_path ]]; then
     git clone --mirror $LUG_source $LUG_path
-    cd $LUG_path
-    git remote add upstream $LUG_target
 fi
 
 cd $LUG_path
 
 git remote set-url origin $LUG_source
-git remote set-url upstream $LUG_target
+git remote add upstream $LUG_target || git remote set-url upstream $LUG_target
 
 git config --unset-all remote.origin.fetch
 git config --add remote.origin.fetch "+refs/heads/*:refs/heads/*"


### PR DESCRIPTION
This PR also:
* adds `x-sjtug-mirror-id` in header
* expose `linuxbrew-bottles`
* fix llvm-project wrong path